### PR TITLE
Bump vulnerable dependencies' versions

### DIFF
--- a/commands/default_token_factory.go
+++ b/commands/default_token_factory.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/cli/plugin"
-	"github.com/dgrijalva/jwt-go"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/client"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // DefaultTokenFactory factory for retrieving tokens
@@ -55,14 +56,12 @@ func (t *DefaultTokenFactory) NewRawToken() (string, error) {
 
 func getTokenExpirationTime(tokenString string) (int64, error) {
 	// Parse jwt token string
-	parser := jwt.Parser{
-		SkipClaimsValidation: true,
-	}
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
 	token, err := parser.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return token, nil
 	})
 
-	if err != nil && err.Error() != "key is of invalid type" {
+	if err != nil && !strings.Contains(err.Error(), "key is of invalid type") {
 		return 0, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.20
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible
 	code.cloudfoundry.org/jsonry v1.1.3
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-openapi/errors v0.20.1
 	github.com/go-openapi/runtime v0.19.31
 	github.com/go-openapi/strfmt v0.20.2
 	github.com/go-openapi/swag v0.19.15
 	github.com/go-openapi/validate v0.20.2
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pborman/uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pborman/uuid v1.2.0
-	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6
+	golang.org/x/net v0.10.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -70,10 +70,10 @@ require (
 	github.com/tedsuo/rata v1.0.0 // indirect
 	github.com/vito/go-interact v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/sys v0.0.0-20211001092434-39dca1131b70 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto v0.0.0-20211102202547-e9cf271f7f2c // indirect
 	google.golang.org/grpc v1.42.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect


### PR DESCRIPTION
 golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 -> v0.10.0
gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b -> v3.0.1
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 -> v0.14.0 
golang.org/x/sys v0.0.0-20211001092434-39dca1131b70 -> v0.13.0 
golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 -> v0.13.0 
golang.org/x/text v0.3.7 -> v0.13.0