### PR TITLE
Check response for error

### DIFF
--- a/clients/baseclient/client_error.go
+++ b/clients/baseclient/client_error.go
@@ -3,7 +3,6 @@ package baseclient
 import (
 	"bytes"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -15,7 +14,6 @@ type ClientError struct {
 	Code        int
 	Status      string
 	Description interface{}
-	Headers     http.Header
 }
 
 func (ce *ClientError) Error() string {
@@ -36,15 +34,6 @@ func NewClientError(err error) error {
 		return &ClientError{Code: response.Code, Status: response.Status, Description: response.Payload}
 	}
 	return err
-}
-
-func NewClientErrorFromHttpResponse(response *http.Response, description string) error {
-	return &ClientError{
-		Code:        response.StatusCode,
-		Status:      response.Status,
-		Description: description,
-		Headers:     response.Header,
-	}
 }
 
 func BuildErrorResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/clients/csrf/csrf_helper.go
+++ b/clients/csrf/csrf_helper.go
@@ -1,10 +1,11 @@
 package csrf
 
 import (
-	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/csrf/csrf_parameters"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/csrf/csrf_parameters"
 )
 
 const CookieHeader = "Cookie"

--- a/clients/csrf/default_csrf_token_fetcher.go
+++ b/clients/csrf/default_csrf_token_fetcher.go
@@ -1,10 +1,11 @@
 package csrf
 
 import (
-	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/csrf/csrf_parameters"
-	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/log"
 	"net/http"
 	"net/url"
+
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/csrf/csrf_parameters"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/log"
 )
 
 const CsrfTokenHeaderFetchValue = "Fetch"


### PR DESCRIPTION
From docs:
	// RoundTrip should not attempt to interpret the response. In
	// particular, RoundTrip must return err == nil if it obtained
	// a response, regardless of the response's HTTP status code.
	// A non-nil err should be reserved for failure to obtain a
	// response. Similarly, RoundTrip should not attempt to
	// handle higher-level protocol details such as redirects,
	// authentication, or cookies.

Instead of checking for error, check the response for 403 and the required csrf token header