### PR TITLE
Fix for #200

### DIFF
--- a/commands/deploy_command.go
+++ b/commands/deploy_command.go
@@ -515,7 +515,7 @@ func (c *DeployCommand) tryReadingFileUrl() string {
 
 	if stat.Mode()&fs.ModeCharDevice == 0 {
 		input := make(chan string, 1)
-		go getInput(input)
+		go getInput(input, c.FileUrlReader)
 		select {
 		case i := <-input:
 			return strings.TrimSpace(i)

--- a/commands/deploy_command.go
+++ b/commands/deploy_command.go
@@ -520,7 +520,7 @@ func (c *DeployCommand) tryReadingFileUrl() string {
 		case i := <-input:
 			return strings.TrimSpace(i)
 		case <- time.After(readStringTimeout):
-			log.Tracef("the timeout period elapsed prios to receiving input from stdin")
+			log.Tracef("the timeout period elapsed prior to receiving input from stdin")
 			return ""
 		}
 	}

--- a/commands/deploy_command.go
+++ b/commands/deploy_command.go
@@ -514,13 +514,15 @@ func (c *DeployCommand) tryReadingFileUrl() string {
 	}
 
 	if stat.Mode()&fs.ModeCharDevice == 0 {
+		// Print flow clarifying message
+		ui.Say("Trying to get MTA archive URL from STDIN")
 		input := make(chan string, 1)
 		go getInput(input, c.FileUrlReader)
 		select {
 		case i := <-input:
 			return strings.TrimSpace(i)
-		case <- time.After(readStringTimeout):
-			log.Tracef("the timeout period elapsed prior to receiving input from stdin")
+		case <-time.After(readStringTimeout):
+			ui.Say(terminal.FailureColor("The timeout period elapsed prior to receiving input from stdin"))
 			return ""
 		}
 	}


### PR DESCRIPTION
#### Description: 
Do not wait for user input forever, instead use internally defined 30 seconds timeout, if no input for url will be received it will start normal building


#### Issue: 
https://github.com/cloudfoundry/multiapps-cli-plugin/issues/200

