### PR TITLE
Enable SonarCloud analysis

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
       with:
-        go-version: '1.24'
+        go-version: '1.25.4'
 
     - name: Download dependencies
       run: go get -d -t ./...

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,0 +1,42 @@
+name: Multiapps CLI Plugin Sonar Scan
+
+on:
+  push:
+   branches: [ "master" ]
+  pull_request:
+   branches: [ "master" ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        # Full history so SonarCloud can compute new-code and blame data.
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+      with:
+        go-version: '1.25.4'
+
+    - name: Build and Test with Coverage
+      run: |
+        go build -v ./...
+        go test -coverprofile=coverage.out ./...
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+      with:
+        args: --output.json.path=golangci-report.json
+      continue-on-error: true
+
+    - name: Sonar Scan
+      uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+# golangci-lint configuration for multiapps-cli-plugin
+# Runs a standard set of Go linters; JSON output is uploaded to SonarCloud.
+run:
+  timeout: 5m
+
+issues:
+  exclude-dirs:
+    - test_resources
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - ineffassign
+    - unused

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=cloudfoundry_multiapps-cli-plugin
+sonar.organization=cloudfoundry
+sonar.projectName="MultiApps CLI Plugin"
+
+# Source and test layout
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.exclusions=\
+    **/test_resources/**
+
+# Go analysis inputs
+sonar.go.coverage.reportPaths=coverage.out
+sonar.go.golangci-lint.reportPaths=golangci-report.json


### PR DESCRIPTION
Add SonarCloud configuration and a CI workflow that runs on push and pull requests to master:

- sonar-project.properties: project key, sources/tests layout, and Go coverage + golangci-lint report paths
- .github/workflows/sonar-scan.yml: build, test with coverage, golangci-lint, and Sonar scan
- .golangci.yml: reproducible linter configuration
- pull-request-build.yml: pin Go to 1.25.4 to match go.mod



